### PR TITLE
Added umbrella flag

### DIFF
--- a/.doctor.exs
+++ b/.doctor.exs
@@ -7,5 +7,6 @@
   min_overall_spec_coverage: 0,
   moduledoc_required: true,
   raise: false,
+  umbrella: false,
   reporter: Doctor.Reporters.Full
 }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Below is a sample `.doctor.exs` file with some sample values for the various fie
   min_overall_spec_coverage: 0,
   moduledoc_required: true,
   raise: false,
+  umbrella: false,
   reporter: Doctor.Reporters.Full
 }
 ```

--- a/lib/cli/cli.ex
+++ b/lib/cli/cli.ex
@@ -9,28 +9,31 @@ defmodule Doctor.CLI do
   @doc """
   Given the CLI arguments, run the report on the project,
   """
-  def run_report(args) do
+  def generate_module_report_list(args) do
     # Using the project's app name, fetch all the modules associated with the app
-    module_report_list =
-      Project.config()
-      |> Keyword.get(:app)
-      |> get_application_modules()
+    Project.config()
+    |> Keyword.get(:app)
+    |> get_application_modules()
 
-      # Fetch the module information from the list of application modules
-      |> Enum.map(&generate_module_entry/1)
+    # Fetch the module information from the list of application modules
+    |> Enum.map(&generate_module_entry/1)
 
-      # Filter out any files/modules that were specified in the config
-      |> Enum.reject(fn module_info -> module_info.module in args.ignore_modules end)
-      |> Enum.reject(fn module_info -> filter_ignore_paths(module_info.file_relative_path, args.ignore_paths) end)
+    # Filter out any files/modules that were specified in the config
+    |> Enum.reject(fn module_info -> module_info.module in args.ignore_modules end)
+    |> Enum.reject(fn module_info -> filter_ignore_paths(module_info.file_relative_path, args.ignore_paths) end)
 
-      # Asynchronously get the user defined functions from the modules
-      |> Enum.map(&async_fetch_user_defined_functions/1)
-      |> Enum.map(&Task.await(&1, 15_000))
+    # Asynchronously get the user defined functions from the modules
+    |> Enum.map(&async_fetch_user_defined_functions/1)
+    |> Enum.map(&Task.await(&1, 15_000))
 
-      # Build report struct for each module
-      |> Enum.sort(&(&1.file_relative_path < &2.file_relative_path))
-      |> Enum.map(&ModuleReport.build/1)
+    # Build report struct for each module
+    |> Enum.sort(&(&1.file_relative_path < &2.file_relative_path))
+    |> Enum.map(&ModuleReport.build/1)
+  end
 
+  @doc """
+  """
+  def process_module_report_list(module_report_list, args) do
     # Invoke the configured module reporter and return whether Doctor validation passed/failed
     args.reporter.generate_report(module_report_list, args)
     ReportUtils.doctor_report_passed?(module_report_list, args)

--- a/lib/cli/cli.ex
+++ b/lib/cli/cli.ex
@@ -32,6 +32,8 @@ defmodule Doctor.CLI do
   end
 
   @doc """
+  Given a list of individual module reports, process each item in the
+  list with the configured reporter and return a pass or fail boolean
   """
   def process_module_report_list(module_report_list, args) do
     # Invoke the configured module reporter and return whether Doctor validation passed/failed

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -14,6 +14,7 @@ defmodule Doctor.Config do
             min_module_doc_coverage: 40,
             min_module_spec_coverage: 0,
             raise: false,
+            umbrella: false,
             ignore_modules: [],
             ignore_paths: [],
             reporter: Doctor.Reporters.Full
@@ -21,7 +22,7 @@ defmodule Doctor.Config do
   @doc """
   Get the configuration defaults as a Config struct
   """
-  def config_defaults_as_map, do: %Config{}
+  def config_defaults, do: %Config{}
 
   @doc """
   Get the configuration defaults as a string

--- a/lib/mix/tasks/doctor.ex
+++ b/lib/mix/tasks/doctor.ex
@@ -3,11 +3,12 @@ defmodule Mix.Tasks.Doctor do
 
   use Mix.Task
 
-  alias Doctor.Config
+  alias Doctor.{CLI, Config}
   alias Doctor.Reporters.{Full, Short, Summary}
 
   @shortdoc "Documentation coverage report"
   @recursive true
+  @umbrella_accumulator Doctor.Umbrella
 
   @doc """
   This Mix task generates a Doctor report of the project.
@@ -19,7 +20,32 @@ defmodule Mix.Tasks.Doctor do
       |> merge_defaults()
       |> merge_cli_args(args)
 
-    result = Doctor.CLI.run_report(config)
+    if config.umbrella do
+      run_umbrella(config)
+    else
+      run_default(config)
+    end
+  end
+
+  defp run_umbrella(config) do
+    module_report_list = CLI.generate_module_report_list(config)
+
+    acc_pid =
+      case Process.whereis(@umbrella_accumulator) do
+        nil -> init_umbrella_acc(config)
+        pid -> pid
+      end
+
+    Agent.update(acc_pid, fn acc ->
+      acc ++ module_report_list
+    end)
+  end
+
+  defp run_default(config) do
+    result =
+      config
+      |> CLI.generate_module_report_list()
+      |> CLI.process_module_report_list(config)
 
     unless result do
       System.at_exit(fn _ ->
@@ -27,11 +53,31 @@ defmodule Mix.Tasks.Doctor do
       end)
 
       if config.raise do
-        Mix.raise("Doctor has encountered an error.")
+        Mix.raise("Doctor validation has failed and raised an error")
       end
     end
 
     :ok
+  end
+
+  defp init_umbrella_acc(config) do
+    {:ok, pid} = Agent.start_link(fn -> [] end, name: @umbrella_accumulator)
+
+    System.at_exit(fn _ ->
+      Agent.get(pid, fn module_report_list ->
+        result = CLI.process_module_report_list(module_report_list, config)
+
+        unless result do
+          if config.raise do
+            Mix.raise("Doctor validation has failed and raised an error")
+          end
+
+          exit({:shutdown, 1})
+        end
+      end)
+    end)
+
+    pid
   end
 
   defp load_config_file(file) do
@@ -58,7 +104,7 @@ defmodule Mix.Tasks.Doctor do
   end
 
   defp merge_defaults(config) do
-    Map.merge(Config.config_defaults_as_map(), config)
+    Map.merge(Config.config_defaults(), config)
   end
 
   defp merge_cli_args(config, args) do
@@ -76,6 +122,9 @@ defmodule Mix.Tasks.Doctor do
 
         "--raise", acc ->
           Map.merge(acc, %{raise: true})
+
+        "--umbrella", acc ->
+          Map.merge(acc, %{umbrella: true})
 
         _, acc ->
           acc

--- a/mix.lock
+++ b/mix.lock
@@ -1,8 +1,8 @@
 %{
-  "decimal": {:hex, :decimal, "1.7.0", "30d6b52c88541f9a66637359ddf85016df9eb266170d53105f02e4a67e00c5aa", [:mix], [], "hexpm"},
-  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm"},
-  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm"},
-  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm"},
-  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm"},
+  "decimal": {:hex, :decimal, "1.7.0", "30d6b52c88541f9a66637359ddf85016df9eb266170d53105f02e4a67e00c5aa", [:mix], [], "hexpm", "771ea78576e5fa505ad58a834f57915c7f5f9df11c87a598a01fdf6065ccfb5d"},
+  "earmark": {:hex, :earmark, "1.3.2", "b840562ea3d67795ffbb5bd88940b1bed0ed9fa32834915125ea7d02e35888a5", [:mix], [], "hexpm", "e3be2bc3ae67781db529b80aa7e7c49904a988596e2dbff897425b48b3581161"},
+  "ex_doc": {:hex, :ex_doc, "0.20.2", "1bd0dfb0304bade58beb77f20f21ee3558cc3c753743ae0ddbb0fd7ba2912331", [:mix], [{:earmark, "~> 1.3", [hex: :earmark, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.10", [hex: :makeup_elixir, repo: "hexpm", optional: false]}], "hexpm", "8e24fc8ff9a50b9f557ff020d6c91a03cded7e59ac3e0eec8a27e771430c7d27"},
+  "makeup": {:hex, :makeup, "0.8.0", "9cf32aea71c7fe0a4b2e9246c2c4978f9070257e5c9ce6d4a28ec450a839b55f", [:mix], [{:nimble_parsec, "~> 0.5.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "5fbc8e549aa9afeea2847c0769e3970537ed302f93a23ac612602e805d9d1e7f"},
+  "makeup_elixir": {:hex, :makeup_elixir, "0.13.0", "be7a477997dcac2e48a9d695ec730b2d22418292675c75aa2d34ba0909dcdeda", [:mix], [{:makeup, "~> 0.8", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "adf0218695e22caeda2820eaba703fa46c91820d53813a2223413da3ef4ba515"},
+  "nimble_parsec": {:hex, :nimble_parsec, "0.5.0", "90e2eca3d0266e5c53f8fbe0079694740b9c91b6747f2b7e3c5d21966bba8300", [:mix], [], "hexpm", "5c040b8469c1ff1b10093d3186e2e10dbe483cd73d79ec017993fb3985b8a9b3"},
 }

--- a/test/mix_doctor_test.exs
+++ b/test/mix_doctor_test.exs
@@ -25,8 +25,8 @@ defmodule Mix.Tasks.DoctorTest do
                ["Summary:\n"],
                ["Passed Modules: 16"],
                ["Failed Modules: 2"],
-               ["Total Doc Coverage: 78.3%"],
-               ["Total Spec Coverage: 23.9%\n"],
+               ["Total Doc Coverage: 78.7%"],
+               ["Total Spec Coverage: 23.4%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]
     end
@@ -40,7 +40,7 @@ defmodule Mix.Tasks.DoctorTest do
                ["Doctor file found. Loading configuration."],
                ["---------------------------------------------------------------------------------"],
                ["Doc Cov  Spec Cov  Functions  Module                                   Module Doc"],
-               ["100%     0%        1          Doctor.CLI                               YES       "],
+               ["100%     0%        2          Doctor.CLI                               YES       "],
                ["100%     0%        3          Doctor.Config                            YES       "],
                ["100%     0%        1          Doctor.Docs                              YES       "],
                ["NA       NA        0          Doctor                                   YES       "],
@@ -62,8 +62,8 @@ defmodule Mix.Tasks.DoctorTest do
                ["Summary:\n"],
                ["Passed Modules: 16"],
                ["Failed Modules: 2"],
-               ["Total Doc Coverage: 78.3%"],
-               ["Total Spec Coverage: 23.9%\n"],
+               ["Total Doc Coverage: 78.7%"],
+               ["Total Spec Coverage: 23.4%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]
     end
@@ -82,7 +82,7 @@ defmodule Mix.Tasks.DoctorTest do
                  "Doc Cov  Spec Cov  Module                                   File                                                                  Functions  No Docs  No Specs  Module Doc"
                ],
                [
-                 "100%     0%        Doctor.CLI                               lib/cli/cli.ex                                                        1          0        1         YES       "
+                 "100%     0%        Doctor.CLI                               lib/cli/cli.ex                                                        2          0        2         YES       "
                ],
                [
                  "100%     0%        Doctor.Config                            lib/config.ex                                                         3          0        3         YES       "
@@ -141,8 +141,8 @@ defmodule Mix.Tasks.DoctorTest do
                ["Summary:\n"],
                ["Passed Modules: 16"],
                ["Failed Modules: 2"],
-               ["Total Doc Coverage: 78.3%"],
-               ["Total Spec Coverage: 23.9%\n"],
+               ["Total Doc Coverage: 78.7%"],
+               ["Total Spec Coverage: 23.4%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]
     end


### PR DESCRIPTION
Added the `--umbrella` flag which aggregates all of the Doctor results from the apps within an umbrella project, and applies all of the threshold validations to the aggregated results. Use `mix doctor --umbrella` to run in this mode. As a note, by default Doctor will validate each app independently.