### PR TITLE
Ignore Module Prefix

### DIFF
--- a/lib/cli/cli.ex
+++ b/lib/cli/cli.ex
@@ -94,7 +94,7 @@ defmodule Doctor.CLI do
   defp filter_ignore_module_prefixes(module, ignore_prefixes) do
     ignore_prefixes
     |> Enum.reduce_while(false, fn prefix, _acc ->
-      if prefix in "#{module}" do
+      if "#{module}" =~ "#{prefix}" do
         {:halt, true}
       else
         {:cont, false}

--- a/lib/cli/cli.ex
+++ b/lib/cli/cli.ex
@@ -92,7 +92,16 @@ defmodule Doctor.CLI do
   end
 
   defp filter_ignore_module_prefixes(module, ignore_prefixes) do
-    Enum.any?(ignore_prefixes, fn prefix -> String.starts_with?("#{module}", "#{prefix}") end)
+    Enum.any?(ignore_prefixes, fn
+      "Elixir." <> _rest = prefix -> compare_ignore_module_prefix("#{module}", prefix)
+      prefix when is_binary(prefix) -> compare_ignore_module_prefix("#{module}", "Elixir." <> prefix)
+      prefix when is_atom(prefix) -> String.starts_with?("#{module}", "#{prefix}")
+      _ -> false
+    end)
+  end
+
+  defp compare_ignore_module_prefix(module, prefix) do
+    String.starts_with?("#{module}", prefix)
   end
 
   defp filter_ignore_paths(file_relative_path, ignore_paths) do

--- a/lib/cli/cli.ex
+++ b/lib/cli/cli.ex
@@ -92,7 +92,7 @@ defmodule Doctor.CLI do
   end
 
   defp filter_ignore_module_prefixes(module, ignore_prefixes) do
-    Enum.any?(ignore_prefixes, fn prefix -> "#{module}" =~ "#{prefix}" end)
+    Enum.any?(ignore_prefixes, fn prefix -> String.starts_with?("#{module}", "#{prefix}") end)
   end
 
   defp filter_ignore_paths(file_relative_path, ignore_paths) do

--- a/lib/cli/cli.ex
+++ b/lib/cli/cli.ex
@@ -21,7 +21,7 @@ defmodule Doctor.CLI do
 
     # Filter out any files/modules that were specified in the config
     |> Enum.reject(fn module_info -> module_info.module in args.ignore_modules end)
-    |> Enum.reject(fn module_info -> filter_ignore_module_prefixes(module_info.module, args.ignore_module_prefixes) end)
+    |> Enum.reject(fn module_info -> filter_ignore_module_regex(module_info.module, args.ignore_modules) end)
     |> Enum.reject(fn module_info -> filter_ignore_paths(module_info.file_relative_path, args.ignore_paths) end)
 
     # Asynchronously get the user defined functions from the modules
@@ -91,7 +91,7 @@ defmodule Doctor.CLI do
     modules
   end
 
-  defp filter_ignore_module_prefixes(module, ignore_prefixes) do
+  defp filter_ignore_module_regex(module, ignore_pres
     Enum.any?(ignore_prefixes, fn
       "Elixir." <> _rest = prefix -> compare_ignore_module_prefix("#{module}", prefix)
       prefix when is_binary(prefix) -> compare_ignore_module_prefix("#{module}", "Elixir." <> prefix)

--- a/lib/cli/cli.ex
+++ b/lib/cli/cli.ex
@@ -101,7 +101,10 @@ defmodule Doctor.CLI do
   end
 
   defp compare_ignore_module_prefix(module, prefix) do
-    String.starts_with?("#{module}", prefix)
+    module
+    |> to_string()
+    |> Regex.compile!()
+    |> Regex.match?(prefix)
   end
 
   defp filter_ignore_paths(file_relative_path, ignore_paths) do

--- a/lib/cli/cli.ex
+++ b/lib/cli/cli.ex
@@ -21,6 +21,7 @@ defmodule Doctor.CLI do
 
     # Filter out any files/modules that were specified in the config
     |> Enum.reject(fn module_info -> module_info.module in args.ignore_modules end)
+    |> Enum.reject(fn module_info -> filter_ignore_module_prefixes(module_info.module, args.ignore_module_prefixes) end)
     |> Enum.reject(fn module_info -> filter_ignore_paths(module_info.file_relative_path, args.ignore_paths) end)
 
     # Asynchronously get the user defined functions from the modules
@@ -88,6 +89,17 @@ defmodule Doctor.CLI do
     {:ok, modules} = :application.get_key(application, :modules)
 
     modules
+  end
+
+  defp filter_ignore_module_prefixes(module, ignore_prefixes) do
+    ignore_prefixes
+    |> Enum.reduce_while(false, fn prefix, _acc ->
+      if prefix in "#{module}" do
+        {:halt, true}
+      else
+        {:cont, false}
+      end
+    end)
   end
 
   defp filter_ignore_paths(file_relative_path, ignore_paths) do

--- a/lib/cli/cli.ex
+++ b/lib/cli/cli.ex
@@ -92,14 +92,7 @@ defmodule Doctor.CLI do
   end
 
   defp filter_ignore_module_prefixes(module, ignore_prefixes) do
-    ignore_prefixes
-    |> Enum.reduce_while(false, fn prefix, _acc ->
-      if "#{module}" =~ "#{prefix}" do
-        {:halt, true}
-      else
-        {:cont, false}
-      end
-    end)
+    Enum.any?(ignore_prefixes, fn prefix -> "#{module}" =~ "#{prefix}" end)
   end
 
   defp filter_ignore_paths(file_relative_path, ignore_paths) do

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -9,8 +9,7 @@ defmodule Doctor.Config do
   alias __MODULE__
 
   @type t :: %Config{
-          ignore_modules: [module()],
-          ignore_module_prefixes: [module() | binary()],
+          ignore_modules: [module() | binary()],
           ignore_paths: [binary()],
           min_module_doc_coverage: integer() | float(),
           min_module_spec_coverage: integer() | float(),
@@ -24,7 +23,6 @@ defmodule Doctor.Config do
         }
 
   defstruct ignore_modules: [],
-            ignore_module_prefixes: [],
             ignore_paths: [],
             min_module_doc_coverage: 40,
             min_module_spec_coverage: 0,

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -9,8 +9,9 @@ defmodule Doctor.Config do
   alias __MODULE__
 
   @type t :: %Config{
-          ignore_modules: [],
-          ignore_paths: [],
+          ignore_modules: [module()],
+          ignore_module_prefixes: [module()],
+          ignore_paths: [binary()],
           min_module_doc_coverage: integer() | float(),
           min_module_spec_coverage: integer() | float(),
           min_overall_doc_coverage: integer() | float(),
@@ -23,6 +24,7 @@ defmodule Doctor.Config do
         }
 
   defstruct ignore_modules: [],
+            ignore_module_prefixes: [],
             ignore_paths: [],
             min_module_doc_coverage: 40,
             min_module_spec_coverage: 0,

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -10,7 +10,7 @@ defmodule Doctor.Config do
 
   @type t :: %Config{
           ignore_modules: [module()],
-          ignore_module_prefixes: [module()],
+          ignore_module_prefixes: [module() | binary()],
           ignore_paths: [binary()],
           min_module_doc_coverage: integer() | float(),
           min_module_spec_coverage: integer() | float(),


### PR DESCRIPTION
- Allows passage of `ignore_module_prefixes: [Jason.Encoder, Mix.Tasks]` to config
- How do you want this tested? It works in the project that I've pulled it into 😄 
