### PR TITLE
fix reporting on multi-clause callbacks

### DIFF
--- a/test/mix_doctor_test.exs
+++ b/test/mix_doctor_test.exs
@@ -98,10 +98,10 @@ defmodule Mix.Tasks.DoctorTest do
       assert rest_doctor_output == [
                ["---------------------------------------------"],
                ["Summary:\n"],
-               ["Passed Modules: 19"],
+               ["Passed Modules: 21"],
                ["Failed Modules: 6"],
                ["Total Doc Coverage: 83.3%"],
-               ["Total Spec Coverage: 35.0%\n"],
+               ["Total Spec Coverage: 36.4%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]
     end

--- a/test/module_report_test.exs
+++ b/test/module_report_test.exs
@@ -54,6 +54,24 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.doc_coverage == Decimal.new("100")
   end
 
+  test "build/1 should build the correct report struct for a file that implements behaviour callbacks with multiple clauses" do
+    module_report =
+      Doctor.FooBar
+      |> Code.fetch_docs()
+      |> ModuleInformation.build(Doctor.FooBar)
+      |> ModuleInformation.load_file_ast()
+      |> ModuleInformation.load_user_defined_functions()
+      |> ModuleReport.build()
+
+    assert module_report.functions == 6
+    assert module_report.has_module_doc
+    assert module_report.missed_docs == 1
+    assert module_report.missed_specs == 3
+    assert module_report.module == "Doctor.FooBar"
+    assert module_report.doc_coverage == Decimal.new("83.33333333333333333333333333")
+    assert module_report.spec_coverage == Decimal.new("50.0")
+  end
+
   test "build/1 should build the correct report struct for a file with no coverage" do
     module_report =
       Doctor.NoDocs

--- a/test/sample_files/behaviour_module.ex
+++ b/test/sample_files/behaviour_module.ex
@@ -16,6 +16,10 @@ defmodule Doctor.BehaviourModule do
     {:reply, head, tail}
   end
 
+  def handle_call(:nop, _from, state) do
+    {:reply, state}
+  end
+
   @impl true
   def handle_cast({:push, element}, state) do
     {:noreply, [element | state]}

--- a/test/sample_files/custom_behaviour_module.ex
+++ b/test/sample_files/custom_behaviour_module.ex
@@ -1,0 +1,49 @@
+defmodule Doctor.FooBarBehaviour do
+  @moduledoc """
+  A custom behaviour module
+  """
+
+  @doc """
+  The famous foo function
+  """
+  @callback foo(mode :: atom()) :: integer()
+
+  @doc """
+  And the infamous bar function
+  """
+  @callback bar(mode :: atom()) :: integer()
+
+  @callback bar(mode :: atom(), param :: integer()) :: integer()
+end
+
+defmodule Doctor.FooBar do
+  @moduledoc """
+  Implementation of the FooBarBehaviour
+  """
+
+  @behaviour Doctor.FooBarBehaviour
+
+  def foo(:five), do: 5
+
+  # This should not
+  @impl true
+  def foo(:one), do: 1
+
+  # neither this
+  def foo(:two), do: 2
+
+  @impl Doctor.FooBarBehaviour
+  def bar(:one), do: 1
+  def bar(:two), do: 2
+  def bar(:three), do: 3
+
+  # This should raise both a missing spec and a missing doc
+  def bar(:test, value), do: value
+
+  # This should pass
+  @impl Doctor.FooBarBehaviour
+  def bar(:bar, value), do: value
+
+  # This should raise both a missing doc and spec
+  def bar(:noop, _value1, _value2), do: 0
+end


### PR DESCRIPTION
In case of multi-clause callbacks a missing spec error was raised for
clause bodies after the first @impl annotation. Fix the bug by
checking if we already have parsed a function/arity body with an
implementation annotation and pass this implementation to all subsequent
clauses.

Add a custom behaviour unit test.