### PR TITLE
Add --failed CLI argument

### DIFF
--- a/lib/config.ex
+++ b/lib/config.ex
@@ -20,7 +20,8 @@ defmodule Doctor.Config do
           raise: boolean(),
           reporter: module(),
           struct_type_spec_required: boolean(),
-          umbrella: boolean()
+          umbrella: boolean(),
+          failed: false
         }
 
   defstruct ignore_modules: [],
@@ -34,7 +35,8 @@ defmodule Doctor.Config do
             raise: false,
             reporter: Doctor.Reporters.Full,
             struct_type_spec_required: true,
-            umbrella: false
+            umbrella: false,
+            failed: false
 
   @doc """
   Get the configuration defaults as a Config struct

--- a/lib/mix/tasks/doctor.ex
+++ b/lib/mix/tasks/doctor.ex
@@ -24,6 +24,9 @@ defmodule Mix.Tasks.Doctor do
   --raise        If any of your modules fails Doctor validation, then
                  raise an error and return a non-zero exit status.
 
+  --failed       If set only the failed modules will be reported. Works with
+                 --full and --short options
+
   --umbrella     By default, in an umbrella project, each app will be
                  evaluated independently against the specified thresholds
                  in your .doctor.exs file. This flag changes that behavior
@@ -165,6 +168,7 @@ defmodule Mix.Tasks.Doctor do
           short: :boolean,
           summary: :boolean,
           raise: :boolean,
+          failed: :boolean,
           umbrella: :boolean,
           config_file: :string
         ]
@@ -176,6 +180,7 @@ defmodule Mix.Tasks.Doctor do
       {:short, true}, acc -> Map.merge(acc, %{reporter: Short})
       {:summary, true}, acc -> Map.merge(acc, %{reporter: Summary})
       {:raise, true}, acc -> Map.merge(acc, %{raise: true})
+      {:failed, true}, acc -> Map.merge(acc, %{failed: true})
       {:umbrella, true}, acc -> Map.merge(acc, %{umbrella: true})
       {:config_file, file_path}, acc -> Map.merge(acc, %{config_file_path: file_path})
       _unexpected_arg, acc -> acc

--- a/lib/reporters/full.ex
+++ b/lib/reporters/full.ex
@@ -47,7 +47,9 @@ defmodule Doctor.Reporters.Full do
         ])
 
       if ReportUtils.module_passed_validation?(module_report, args) do
-        Mix.shell().info(output_line)
+        unless args.failed do
+          Mix.shell().info(output_line)
+        end
       else
         Mix.shell().info(ANSI.red() <> output_line <> ANSI.reset())
       end

--- a/lib/reporters/short.ex
+++ b/lib/reporters/short.ex
@@ -41,7 +41,9 @@ defmodule Doctor.Reporters.Short do
         ])
 
       if ReportUtils.module_passed_validation?(module_report, args) do
-        Mix.shell().info(output_line)
+        unless args.failed do
+          Mix.shell().info(output_line)
+        end
       else
         Mix.shell().info(ANSI.red() <> output_line <> ANSI.reset())
       end

--- a/test/mix_doctor_test.exs
+++ b/test/mix_doctor_test.exs
@@ -123,6 +123,49 @@ defmodule Mix.Tasks.DoctorTest do
              ]
     end
 
+    test "should output the failed modules and the summary report when --failed is provided" do
+      Mix.Tasks.Doctor.run([
+        "--short",
+        "--failed",
+        "--config-file",
+        "./test/configs/exceptions_moduledoc_not_required.exs"
+      ])
+
+      remove_at_exit_hook()
+      doctor_output = get_shell_output()
+
+      assert doctor_output == [
+               ["Doctor file found. Loading configuration."],
+               ["----------------------------------------------------------------------------------------------"],
+               ["Doc Cov  Spec Cov  Functions  Module                                   Module Doc  Struct Spec"],
+               [
+                 "\e[31mN/A      N/A       0          Doctor.AnotherBehaviourModule.Behaviour  No          N/A        \e[0m"
+               ],
+               [
+                 "\e[31m100%     100%      1          Doctor.AnotherBehaviourModule            No          N/A        \e[0m"
+               ],
+               [
+                 "\e[31m0%       0%        7          Doctor.NoDocs                            No          N/A        \e[0m"
+               ],
+               [
+                 "\e[31mN/A      N/A       0          Doctor.NoStructSpecModule                No          No         \e[0m"
+               ],
+               [
+                 "\e[31m57%      57%       7          Doctor.PartialDocs                       No          N/A        \e[0m"
+               ],
+               [
+                 "\e[31mN/A      N/A       0          Doctor.StructSpecModule                  No          Yes        \e[0m"
+               ],
+               ["----------------------------------------------------------------------------------------------"],
+               ["Summary:\n"],
+               ["Passed Modules: 22"],
+               ["Failed Modules: 6"],
+               ["Total Doc Coverage: 83.6%"],
+               ["Total Spec Coverage: 37.3%\n"],
+               ["\e[31mDoctor validation has failed!\e[0m"]
+             ]
+    end
+
     test "should output the summary report when a doctor file path is provided" do
       Mix.Tasks.Doctor.run(["--summary", "--config-file", "./.doctor.exs"])
       remove_at_exit_hook()


### PR DESCRIPTION
@akoutmos one more small PR. In big codebases it would be useful to have an option for printing only the failed modules. 