### PR TITLE
Handle properly modules with `__using__` macro

### DIFF
--- a/lib/module_report.ex
+++ b/lib/module_report.ex
@@ -65,9 +65,19 @@ defmodule Doctor.ModuleReport do
         {function, arity}
       end)
 
-    Enum.count(module_info.docs, fn doc ->
-      {doc.name, doc.arity} in function_arity_list and doc.doc == :none
-    end)
+    docs_arity_list = Enum.map(module_info.docs, fn doc -> {doc.name, doc.arity} end)
+
+    functions_not_in_docs =
+      Enum.count(function_arity_list, fn fun ->
+        fun not in docs_arity_list
+      end)
+
+    functions_without_docs =
+      Enum.count(module_info.docs, fn doc ->
+        {doc.name, doc.arity} in function_arity_list and doc.doc == :none
+      end)
+
+    functions_not_in_docs + functions_without_docs
   end
 
   defp calculate_doc_coverage(module_info) do

--- a/test/mix_doctor_test.exs
+++ b/test/mix_doctor_test.exs
@@ -98,10 +98,10 @@ defmodule Mix.Tasks.DoctorTest do
       assert rest_doctor_output == [
                ["---------------------------------------------"],
                ["Summary:\n"],
-               ["Passed Modules: 21"],
+               ["Passed Modules: 22"],
                ["Failed Modules: 7"],
-               ["Total Doc Coverage: 83.6%"],
-               ["Total Spec Coverage: 37.3%\n"],
+               ["Total Doc Coverage: 81.7%"],
+               ["Total Spec Coverage: 38.0%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]
     end
@@ -116,9 +116,9 @@ defmodule Mix.Tasks.DoctorTest do
                ["---------------------------------------------"],
                ["Summary:\n"],
                ["Passed Modules: 22"],
-               ["Failed Modules: 6"],
-               ["Total Doc Coverage: 83.6%"],
-               ["Total Spec Coverage: 37.3%\n"],
+               ["Failed Modules: 7"],
+               ["Total Doc Coverage: 81.7%"],
+               ["Total Spec Coverage: 38.0%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]
     end
@@ -156,12 +156,15 @@ defmodule Mix.Tasks.DoctorTest do
                [
                  "\e[31mN/A      N/A       0          Doctor.StructSpecModule                  No          Yes        \e[0m"
                ],
+               [
+                 "\e[31m50%      50%       4          Doctor.UseModule                         Yes         N/A        \e[0m"
+               ],
                ["----------------------------------------------------------------------------------------------"],
                ["Summary:\n"],
                ["Passed Modules: 22"],
-               ["Failed Modules: 6"],
-               ["Total Doc Coverage: 83.6%"],
-               ["Total Spec Coverage: 37.3%\n"],
+               ["Failed Modules: 7"],
+               ["Total Doc Coverage: 81.7%"],
+               ["Total Spec Coverage: 38.0%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]
     end
@@ -356,6 +359,32 @@ defmodule Mix.Tasks.DoctorTest do
                ["\e[32m  Doc Coverage:    100.0%\e[0m"],
                ["\e[32m  Spec Coverage:   100.0%\e[0m"],
                ["\e[32m  Has Module Doc:  ✗\e[0m"],
+               ["\e[32m  Has Struct Spec: N/A\e[0m"]
+             ]
+    end
+
+    test "module with using macro and various inline functions" do
+      Mix.Tasks.Doctor.Explain.run([
+        "--config-file",
+        "./test/configs/exceptions_moduledoc_not_required.exs",
+        "Doctor.UseModule"
+      ])
+
+      remove_at_exit_hook()
+      doctor_output = get_shell_output()
+
+      assert doctor_output == [
+               ["Doctor file found. Loading configuration."],
+               ["\nFunction                     @doc  @spec  "],
+               ["----------------------------------------"],
+               ["fun_without_spec_and_doc/0   ✗     ✗     "],
+               ["fun_with_spec/0              ✗     ✓     "],
+               ["fun_with_doc/0               ✓     ✗     "],
+               ["fun_with_doc_and_spec/0      ✓     ✓     "],
+               ["\nModule Results:"],
+               ["\e[31m  Doc Coverage:    50.0%  --> Your config has a 'min_module_doc_coverage' value of 80\e[0m"],
+               ["\e[32m  Spec Coverage:   50.0%\e[0m"],
+               ["\e[32m  Has Module Doc:  ✓\e[0m"],
                ["\e[32m  Has Struct Spec: N/A\e[0m"]
              ]
     end

--- a/test/module_report_test.exs
+++ b/test/module_report_test.exs
@@ -150,4 +150,24 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.doc_coverage == Decimal.new("100")
     assert module_report.properties == [is_exception: true]
   end
+
+  test "build/1 should build the correct report for a module wiht __using__ macro" do
+    module_report =
+      Doctor.UseModule
+      |> Code.fetch_docs()
+      |> ModuleInformation.build(Doctor.UseModule)
+      |> ModuleInformation.load_file_ast()
+      |> ModuleInformation.load_user_defined_functions()
+      |> ModuleReport.build()
+
+    assert module_report.functions == 4
+    assert module_report.has_module_doc
+    assert module_report.has_struct_type_spec == :not_struct
+    assert module_report.missed_docs == 2
+    assert module_report.missed_specs == 2
+    assert module_report.module == "Doctor.UseModule"
+    assert module_report.doc_coverage == Decimal.new("50.0")
+    assert module_report.spec_coverage == Decimal.new("50.0")
+    assert module_report.properties == [is_exception: false]
+  end
 end

--- a/test/sample_files/use_module.ex
+++ b/test/sample_files/use_module.ex
@@ -1,0 +1,24 @@
+defmodule Doctor.UseModule do
+  @moduledoc """
+  A module with __using__ macro
+  """
+  defmacro __using__(_opts) do
+    quote do
+      @doc """
+      Returns :ok
+      """
+      @spec fun_with_doc_and_spec() :: :ok
+      def fun_with_doc_and_spec, do: :ok
+
+      @doc """
+      Sample function
+      """
+      def fun_with_doc, do: :ok
+
+      @spec fun_with_spec() :: :ok
+      def fun_with_spec, do: :ok
+
+      def fun_without_spec_and_doc, do: :ok
+    end
+  end
+end


### PR DESCRIPTION
Traverse the AST in case of modules with `__using__` macro and extend
the `docs` and `specs` structs.

Closes #34