### PR TITLE
Properly collect functions for nested modules

### DIFF
--- a/test/mix_doctor_test.exs
+++ b/test/mix_doctor_test.exs
@@ -87,7 +87,7 @@ defmodule Mix.Tasks.DoctorTest do
              ]
     end
 
-    test "should output the summary report along with an error when an invalid  doctor file path is provided" do
+    test "should output the summary report along with an error when an invalid doctor file path is provided" do
       Mix.Tasks.Doctor.run(["--summary", "--config-file", "./not_a_real_file.exs"])
       remove_at_exit_hook()
       [[first_line] | rest_doctor_output] = get_shell_output()
@@ -98,10 +98,10 @@ defmodule Mix.Tasks.DoctorTest do
       assert rest_doctor_output == [
                ["---------------------------------------------"],
                ["Summary:\n"],
-               ["Passed Modules: 22"],
+               ["Passed Modules: 24"],
                ["Failed Modules: 7"],
-               ["Total Doc Coverage: 81.7%"],
-               ["Total Spec Coverage: 38.0%\n"],
+               ["Total Doc Coverage: 82.2%"],
+               ["Total Spec Coverage: 39.7%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]
     end
@@ -115,10 +115,10 @@ defmodule Mix.Tasks.DoctorTest do
                ["Doctor file found. Loading configuration."],
                ["---------------------------------------------"],
                ["Summary:\n"],
-               ["Passed Modules: 22"],
+               ["Passed Modules: 24"],
                ["Failed Modules: 7"],
-               ["Total Doc Coverage: 81.7%"],
-               ["Total Spec Coverage: 38.0%\n"],
+               ["Total Doc Coverage: 82.2%"],
+               ["Total Spec Coverage: 39.7%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]
     end
@@ -161,10 +161,10 @@ defmodule Mix.Tasks.DoctorTest do
                ],
                ["----------------------------------------------------------------------------------------------"],
                ["Summary:\n"],
-               ["Passed Modules: 22"],
+               ["Passed Modules: 24"],
                ["Failed Modules: 7"],
-               ["Total Doc Coverage: 81.7%"],
-               ["Total Spec Coverage: 38.0%\n"],
+               ["Total Doc Coverage: 82.2%"],
+               ["Total Spec Coverage: 39.7%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]
     end

--- a/test/module_information_test.exs
+++ b/test/module_information_test.exs
@@ -47,24 +47,48 @@ defmodule Doctor.ModuleInformationTest do
     end
   end
 
-  test "load_user_defined_functions/1 should load user defined functions from AST" do
-    module_information =
-      Doctor.AllDocs
-      |> Code.fetch_docs()
-      |> ModuleInformation.build(Doctor.AllDocs)
-      |> ModuleInformation.load_file_ast()
-      |> ModuleInformation.load_user_defined_functions()
+  describe "load_user_defined_functions/1" do
+    test "should load user defined functions from AST" do
+      module_information =
+        Doctor.AllDocs
+        |> Code.fetch_docs()
+        |> ModuleInformation.build(Doctor.AllDocs)
+        |> ModuleInformation.load_file_ast()
+        |> ModuleInformation.load_user_defined_functions()
 
-    assert module_information != nil
+      assert module_information != nil
 
-    assert Enum.sort(module_information.user_defined_functions) == [
-             {:func_1, 1, :none},
-             {:func_2, 1, :none},
-             {:func_3, 1, :none},
-             {:func_4, 1, :none},
-             {:func_5, 2, :none},
-             {:func_5, 3, :none},
-             {:func_6, 1, :none}
-           ]
+      assert Enum.sort(module_information.user_defined_functions) == [
+               {:func_1, 1, :none},
+               {:func_2, 1, :none},
+               {:func_3, 1, :none},
+               {:func_4, 1, :none},
+               {:func_5, 2, :none},
+               {:func_5, 3, :none},
+               {:func_6, 1, :none}
+             ]
+    end
+
+    test "parent of nested module should ignore functions from nested modules" do
+      module_information =
+        Doctor.ParentModule
+        |> Code.fetch_docs()
+        |> ModuleInformation.build(Doctor.ParentModule)
+        |> ModuleInformation.load_file_ast()
+        |> ModuleInformation.load_user_defined_functions()
+
+      assert module_information.user_defined_functions == [{:outer, 0, :none}]
+    end
+
+    test "nested module should include its functions" do
+      module_information =
+        Doctor.ParentModule.Nested
+        |> Code.fetch_docs()
+        |> ModuleInformation.build(Doctor.ParentModule.Nested)
+        |> ModuleInformation.load_file_ast()
+        |> ModuleInformation.load_user_defined_functions()
+
+      assert module_information.user_defined_functions == [{:inner, 0, :none}]
+    end
   end
 end

--- a/test/module_report_test.exs
+++ b/test/module_report_test.exs
@@ -151,7 +151,7 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.properties == [is_exception: true]
   end
 
-  test "build/1 should build the correct report for a module wiht __using__ macro" do
+  test "build/1 should build the correct report for a module with __using__ macro" do
     module_report =
       Doctor.UseModule
       |> Code.fetch_docs()
@@ -168,6 +168,46 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.module == "Doctor.UseModule"
     assert module_report.doc_coverage == Decimal.new("50.0")
     assert module_report.spec_coverage == Decimal.new("50.0")
+    assert module_report.properties == [is_exception: false]
+  end
+
+  test "build/1 should build the correct report for a module with a nested module" do
+    module_report =
+      Doctor.ParentModule
+      |> Code.fetch_docs()
+      |> ModuleInformation.build(Doctor.ParentModule)
+      |> ModuleInformation.load_file_ast()
+      |> ModuleInformation.load_user_defined_functions()
+      |> ModuleReport.build()
+
+    assert module_report.functions == 1
+    assert module_report.has_module_doc
+    assert module_report.has_struct_type_spec == :not_struct
+    assert module_report.missed_docs == 0
+    assert module_report.missed_specs == 0
+    assert module_report.module == "Doctor.ParentModule"
+    assert module_report.doc_coverage == Decimal.new("100")
+    assert module_report.spec_coverage == Decimal.new("100")
+    assert module_report.properties == [is_exception: false]
+  end
+
+  test "build/1 should build the correct report for a nested module" do
+    module_report =
+      Doctor.ParentModule.Nested
+      |> Code.fetch_docs()
+      |> ModuleInformation.build(Doctor.ParentModule.Nested)
+      |> ModuleInformation.load_file_ast()
+      |> ModuleInformation.load_user_defined_functions()
+      |> ModuleReport.build()
+
+    assert module_report.functions == 1
+    assert module_report.has_module_doc
+    assert module_report.has_struct_type_spec == :not_struct
+    assert module_report.missed_docs == 0
+    assert module_report.missed_specs == 0
+    assert module_report.module == "Doctor.ParentModule.Nested"
+    assert module_report.doc_coverage == Decimal.new("100")
+    assert module_report.spec_coverage == Decimal.new("100")
     assert module_report.properties == [is_exception: false]
   end
 end

--- a/test/sample_files/nested_module.ex
+++ b/test/sample_files/nested_module.ex
@@ -1,0 +1,23 @@
+defmodule Doctor.ParentModule do
+  @moduledoc """
+  A module containing another module
+  """
+
+  defmodule Nested do
+    @moduledoc """
+    A nested module
+    """
+
+    @doc """
+    A function in the nested module
+    """
+    @spec inner :: :ok
+    def inner, do: :ok
+  end
+
+  @doc """
+  A function in the outer module
+  """
+  @spec outer :: :ok
+  def outer, do: :ok
+end


### PR DESCRIPTION
Fixes #40 

Thanks for this library! I've been looking for something like this for a while, and I'm glad I stumbled across it.

There were two issues:

- The parent of a nested module would include all of the functions from its nested modules

- A nested module wouldn't include any of its functions

The first issue occurred because `ModuleInformation.load_user_defined_functions` wasn't taking into account nested `defmodule` statements.

To fix this:
- Add a `nesting_level` to the accumulator when looking for functions.
- Switch to using `Macro.traverse/4` so that we can properly keep track of the current module nesting level.
- Ignore any `def` statements at nesting level > 1.

The second issue was caused because the `modules` map in `Module.load_user_defined_functions` was not using fully-qualified names for the nested modules. As a result, when attempting to find the nested module's functions (which uses the fully-qualified name), the module's AST wasn't found.

To fix this:
- Convert the accumulator to include a module `stack`.
- Switch to using `Macro.traverse/4` so that we can properly maintain the stack as we enter and exit modules.
- Compute the fully-qualified name of any nested module and use that as a key in the `modules` map.

Note that nested modules can also include `defimpl`s, so we also check for those when looking for functions.

This was the best way I could find to fix the issues with nested modules, but I'm happy to consider better solutions now that I understand the root of the problem.

I ran this version against our codebase and it fixes all of the false positives we had that were caused by this bug.