### PR TITLE
fix: allow different arguments to __using__

### DIFF
--- a/lib/module_information.ex
+++ b/lib/module_information.ex
@@ -273,11 +273,8 @@ defmodule Doctor.ModuleInformation do
   defp get_function_arity(nil), do: 0
   defp get_function_arity(args), do: length(args)
 
-  defp parse_ast_for_using(
-         {:defmacro, _macro_line, [{:__using__, _line, [{:_opts, _opts_line, _opts}]}, do_block]} = ast,
-         _acc
-       ),
-       do: {ast, %{using: do_block}}
+  defp parse_ast_for_using({:defmacro, _macro_line, [{:__using__, _line, _args}, do_block]} = ast, _acc),
+    do: {ast, %{using: do_block}}
 
   defp parse_ast_for_using(ast, acc), do: {ast, acc}
 


### PR DESCRIPTION
`ModuleInformation.parse_ast_for_using` would only handle `using` blocks with a single argument named `_opts`.

In cases where the argument was named differently (for example, `opts` because the options are needed by the block), the `__using__` block would not be detected.

This change generalizes the pattern match a bit so that it accepts an array with a single argument (which is what `__using__` requires), but makes no assumptions about the name of the argument.

It didn't seem worth it to add a new test for this case. I could have changed the name of the argument in `Doctor.UseModule`, but what's there is pretty conventional. So, in the end, I decided to leave the tests as-is. I can revisit that choice if you prefer.