### PR TITLE
Allow doctor.explain to work in umbrella apps

### DIFF
--- a/lib/cli/cli.ex
+++ b/lib/cli/cli.ex
@@ -44,15 +44,15 @@ defmodule Doctor.CLI do
     end)
     |> case do
       :not_found ->
-        raise "Could not find module #{inspect(module_name)} in application"
+        :not_found
 
       module ->
         module
         |> generate_module_entry()
         |> async_fetch_user_defined_functions()
         |> Task.await(15_000)
+        |> ModuleExplain.generate_report(args)
     end
-    |> ModuleExplain.generate_report(args)
   end
 
   @doc """


### PR DESCRIPTION
Resolves #26 

Modifies `mix doctor.explain` so that it will work in umbrella apps.

As with `mix doctor`, this starts up an accumulator agent for umbrella apps and collects the results from each application in the umbrella.

If the module is not found in any of the apps, the standard "Could not find module" exception is raised.

If the module is found in one or more of the apps, then tne final result is `true` if it was `true` in each of the apps where it was found and `false` otherwise.

It seems very unlikely that the same module would be found in multiple apps, but this implementation supports that in case it happens.

To make this work more cleanly, `CLI.generate_single_module_report` returns `:not_found` if the module wasn't found rather than immediately raising an exception. This allows the `doctor.explain` task to capture the result and raise the exception later, if necessary.