### PR TITLE
Fix moduledoc detection for older elixir versions

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -1,6 +1,6 @@
 # This file is responsible for configuring your application
 # and its dependencies with the aid of the Mix.Config module.
-use Mix.Config
+import Config
 
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this

--- a/lib/module_report.ex
+++ b/lib/module_report.ex
@@ -131,6 +131,6 @@ defmodule Doctor.ModuleReport do
   end
 
   defp has_module_doc?(module_info) do
-    module_info.module_doc != :none
+    module_info.module_doc not in [:none, %{}]
   end
 end


### PR DESCRIPTION
I noticed that in my application, the `Module Doc` column in the report was all `Yes` even though I know many modules do not have moduledocs. Looking deeper, I notice that `module_info.module_doc` is returning things like the following, but never `:none` as doctor is expecting.

```
:hidden
%{}
%{
  "en" => "This is an actual moduledoc content in our app"
}
```

The reason seems to be that we've got our app on elixir 1.12.3, and it is apparently giving doctor `%{}` instead of `:none` as newer elixirs do.

Is it worthwhile to make a change here to support older versions of elixir? And I'm not sure what `:hidden` means...

Thanks, Alex !