### PR TITLE
Fix #45 by ignoring protocol implementations

### DIFF
--- a/lib/module_information.ex
+++ b/lib/module_information.ex
@@ -59,7 +59,8 @@ defmodule Doctor.ModuleInformation do
       user_defined_functions: nil,
       struct_type_spec: contains_struct_type_spec?(module),
       properties: [
-        is_exception: is_exception?(module)
+        is_exception: is_exception?(module),
+        is_protocol_implementation: is_protocol_implementation?(module)
       ]
     }
   end
@@ -106,6 +107,10 @@ defmodule Doctor.ModuleInformation do
 
   defp is_exception?(module) when is_atom(module) do
     function_exported?(module, :__struct__, 0) and :__exception__ in Map.keys(module.__struct__())
+  end
+
+  defp is_protocol_implementation?(module) when is_atom(module) do
+    function_exported?(module, :__impl__, 1)
   end
 
   @doc """

--- a/lib/module_report.ex
+++ b/lib/module_report.ex
@@ -18,6 +18,7 @@ defmodule Doctor.ModuleReport do
           missed_specs: integer(),
           has_module_doc: boolean(),
           has_struct_type_spec: atom() | boolean(),
+          is_protocol_implementation: boolean(),
           properties: Keyword.t()
         }
 
@@ -31,6 +32,7 @@ defmodule Doctor.ModuleReport do
     missed_specs
     has_module_doc
     has_struct_type_spec
+    is_protocol_implementation
     properties
   )a
 
@@ -49,6 +51,7 @@ defmodule Doctor.ModuleReport do
       missed_specs: calculate_missed_specs(module_info),
       has_module_doc: has_module_doc?(module_info),
       has_struct_type_spec: module_info.struct_type_spec,
+      is_protocol_implementation: is_protocol_implementation?(module_info),
       properties: module_info.properties
     }
   end
@@ -132,5 +135,9 @@ defmodule Doctor.ModuleReport do
 
   defp has_module_doc?(module_info) do
     module_info.module_doc not in [:none, %{}]
+  end
+
+  defp is_protocol_implementation?(module_info) do
+    Keyword.get(module_info.properties, :is_protocol_implementation)
   end
 end

--- a/lib/reporters/full.ex
+++ b/lib/reporters/full.ex
@@ -30,7 +30,7 @@ defmodule Doctor.Reporters.Full do
     Enum.each(module_reports, fn module_report ->
       doc_cov = massage_coverage(module_report.doc_coverage)
       spec_cov = massage_coverage(module_report.spec_coverage)
-      module_doc = massage_module_doc(module_report.has_module_doc)
+      module_doc = massage_module_doc(module_report)
       struct_type_spec = massage_struct_type_spec(module_report.has_struct_type_spec)
 
       output_line =
@@ -137,9 +137,9 @@ defmodule Doctor.Reporters.Full do
     end
   end
 
-  defp massage_module_doc(module_doc) do
-    if module_doc, do: "Yes", else: "No"
-  end
+  defp massage_module_doc(%{is_protocol_implementation: true}), do: "N/A"
+  defp massage_module_doc(%{has_module_doc: true}), do: "Yes"
+  defp massage_module_doc(%{has_module_doc: false}), do: "No"
 
   defp massage_struct_type_spec(:not_struct), do: "N/A"
   defp massage_struct_type_spec(true), do: "Yes"

--- a/lib/reporters/module_explain.ex
+++ b/lib/reporters/module_explain.ex
@@ -79,6 +79,8 @@ defmodule Doctor.Reporters.ModuleExplain do
     valid_module?(module_report, config)
   end
 
+  defp valid_module?(%ModuleReport{is_protocol_implementation: true}, _config), do: true
+
   defp valid_module?(module_report, config) do
     valid_struct_spec?(module_report, config) and
       valid_moduledoc?(module_report, config) and
@@ -91,10 +93,14 @@ defmodule Doctor.Reporters.ModuleExplain do
       module_report.has_struct_type_spec
   end
 
+  defp valid_moduledoc?(%ModuleReport{is_protocol_implementation: true}, _config), do: true
+
   defp valid_moduledoc?(module_report, config) do
     (not config.exception_moduledoc_required and module_report.properties[:is_exception]) or
       (Config.moduledoc_required?(config) and module_report.has_module_doc)
   end
+
+  defp valid_doc_coverage?(%ModuleReport{is_protocol_implementation: true}, _config), do: true
 
   defp valid_doc_coverage?(module_report, config) do
     doc_coverage(module_report) >= config.min_module_doc_coverage
@@ -128,6 +134,10 @@ defmodule Doctor.Reporters.ModuleExplain do
     end
   end
 
+  defp print_module_doc(%ModuleReport{is_protocol_implementation: true}, %Config{} = _config) do
+    OutputUtils.print_success("  Has Module Doc:  N/A")
+  end
+
   defp print_module_doc(%ModuleReport{} = module_report, %Config{} = config) do
     if valid_moduledoc?(module_report, config) do
       OutputUtils.print_success("  Has Module Doc:  #{OutputUtils.print_pass_or_fail(module_report.has_module_doc)}")
@@ -147,6 +157,10 @@ defmodule Doctor.Reporters.ModuleExplain do
     end
   end
 
+  defp print_doc_coverage(%ModuleReport{is_protocol_implementation: true}, %Config{} = _config) do
+    OutputUtils.print_success("  Doc Coverage:    N/A")
+  end
+
   defp print_doc_coverage(%ModuleReport{} = module_report, %Config{} = config) do
     doc_coverage = doc_coverage(module_report)
 
@@ -157,6 +171,10 @@ defmodule Doctor.Reporters.ModuleExplain do
         "  Doc Coverage:    #{doc_coverage}%  --> Your config has a 'min_module_doc_coverage' value of #{config.min_module_doc_coverage}"
       )
     end
+  end
+
+  defp print_spec_coverage(%ModuleReport{is_protocol_implementation: true}, %Config{} = _config) do
+    OutputUtils.print_success("  Spec Coverage:   N/A")
   end
 
   defp print_spec_coverage(%ModuleReport{} = module_report, %Config{} = config) do

--- a/lib/reporters/short.ex
+++ b/lib/reporters/short.ex
@@ -27,7 +27,7 @@ defmodule Doctor.Reporters.Short do
     Enum.each(module_reports, fn module_report ->
       doc_cov = massage_coverage(module_report.doc_coverage)
       spec_cov = massage_coverage(module_report.spec_coverage)
-      module_doc = massage_module_doc(module_report.has_module_doc)
+      module_doc = massage_module_doc(module_report)
       struct_type_spec = massage_struct_type_spec(module_report.has_struct_type_spec)
 
       output_line =
@@ -114,9 +114,9 @@ defmodule Doctor.Reporters.Short do
     end
   end
 
-  defp massage_module_doc(module_doc) do
-    if module_doc, do: "Yes", else: "No"
-  end
+  defp massage_module_doc(%{is_protocol_implementation: true}), do: "N/A"
+  defp massage_module_doc(%{has_module_doc: true}), do: "Yes"
+  defp massage_module_doc(%{has_module_doc: false}), do: "No"
 
   defp massage_struct_type_spec(:not_struct), do: "N/A"
   defp massage_struct_type_spec(true), do: "Yes"

--- a/test/mix_doctor_test.exs
+++ b/test/mix_doctor_test.exs
@@ -99,10 +99,10 @@ defmodule Mix.Tasks.DoctorTest do
       assert rest_doctor_output == [
                ["---------------------------------------------"],
                ["Summary:\n"],
-               ["Passed Modules: 24"],
+               ["Passed Modules: 28"],
                ["Failed Modules: 8"],
                ["Total Doc Coverage: 82.9%"],
-               ["Total Moduledoc Coverage: 75.0%"],
+               ["Total Moduledoc Coverage: 76.5%"],
                ["Total Spec Coverage: 42.1%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]
@@ -117,10 +117,10 @@ defmodule Mix.Tasks.DoctorTest do
                ["Doctor file found. Loading configuration."],
                ["---------------------------------------------"],
                ["Summary:\n"],
-               ["Passed Modules: 24"],
+               ["Passed Modules: 28"],
                ["Failed Modules: 8"],
                ["Total Doc Coverage: 82.9%"],
-               ["Total Moduledoc Coverage: 75.0%"],
+               ["Total Moduledoc Coverage: 76.5%"],
                ["Total Spec Coverage: 42.1%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]
@@ -167,10 +167,10 @@ defmodule Mix.Tasks.DoctorTest do
                ],
                ["----------------------------------------------------------------------------------------------"],
                ["Summary:\n"],
-               ["Passed Modules: 24"],
+               ["Passed Modules: 28"],
                ["Failed Modules: 8"],
                ["Total Doc Coverage: 82.9%"],
-               ["Total Moduledoc Coverage: 75.0%"],
+               ["Total Moduledoc Coverage: 76.5%"],
                ["Total Spec Coverage: 42.1%\n"],
                ["\e[31mDoctor validation has failed!\e[0m"]
              ]

--- a/test/module_report_test.exs
+++ b/test/module_report_test.exs
@@ -18,7 +18,7 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.missed_specs == 0
     assert module_report.module == "Doctor.AllDocs"
     assert module_report.doc_coverage == Decimal.new("100")
-    assert module_report.properties == [is_exception: false]
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: false]
   end
 
   test "build/1 should build the correct report struct for a file with partial coverage" do
@@ -36,7 +36,7 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.missed_specs == 3
     assert module_report.module == "Doctor.PartialDocs"
     assert module_report.doc_coverage == Decimal.new("57.14285714285714285714285714")
-    assert module_report.properties == [is_exception: false]
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: false]
   end
 
   test "build/1 should build the correct report struct for a file that implements behaviour callbacks" do
@@ -54,7 +54,7 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.missed_specs == 0
     assert module_report.module == "Doctor.BehaviourModule"
     assert module_report.doc_coverage == Decimal.new("100")
-    assert module_report.properties == [is_exception: false]
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: false]
   end
 
   test "build/1 should build the correct report struct for a file that implements behaviour callbacks with multiple clauses" do
@@ -73,7 +73,7 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.module == "Doctor.FooBar"
     assert module_report.doc_coverage == Decimal.new("83.33333333333333333333333333")
     assert module_report.spec_coverage == Decimal.new("50.0")
-    assert module_report.properties == [is_exception: false]
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: false]
   end
 
   test "build/1 should build the correct report struct for a file with no coverage" do
@@ -91,7 +91,7 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.missed_specs == 7
     assert module_report.module == "Doctor.NoDocs"
     assert module_report.doc_coverage == Decimal.new("0")
-    assert module_report.properties == [is_exception: false]
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: false]
   end
 
   test "build/1 should build the correct report struct for a file with struct specs" do
@@ -110,7 +110,7 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.missed_specs == 0
     assert module_report.module == "Doctor.StructSpecModule"
     assert module_report.doc_coverage == nil
-    assert module_report.properties == [is_exception: false]
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: false]
   end
 
   test "build/1 should build the correct report struct for a file with no struct specs" do
@@ -129,7 +129,7 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.missed_specs == 0
     assert module_report.module == "Doctor.NoStructSpecModule"
     assert module_report.doc_coverage == nil
-    assert module_report.properties == [is_exception: false]
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: false]
   end
 
   test "build/1 should build the correct report struct for a file with an opaque struct spec" do
@@ -148,7 +148,7 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.missed_specs == 0
     assert module_report.module == "Doctor.OpaqueStructSpecModule"
     assert module_report.doc_coverage == nil
-    assert module_report.properties == [is_exception: false]
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: false]
   end
 
   test "build/1 should build the correct report for an exception" do
@@ -167,7 +167,7 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.missed_specs == 0
     assert module_report.module == "Doctor.Exception"
     assert module_report.doc_coverage == Decimal.new("100")
-    assert module_report.properties == [is_exception: true]
+    assert module_report.properties == [is_exception: true, is_protocol_implementation: false]
   end
 
   test "build/1 should build the correct report for a module with __using__ macro" do
@@ -187,7 +187,7 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.module == "Doctor.UseModule"
     assert module_report.doc_coverage == Decimal.new("50.0")
     assert module_report.spec_coverage == Decimal.new("50.0")
-    assert module_report.properties == [is_exception: false]
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: false]
   end
 
   test "build/1 should build the correct report for a module with a nested module" do
@@ -207,7 +207,7 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.module == "Doctor.ParentModule"
     assert module_report.doc_coverage == Decimal.new("100")
     assert module_report.spec_coverage == Decimal.new("100")
-    assert module_report.properties == [is_exception: false]
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: false]
   end
 
   test "build/1 should build the correct report for a nested module" do
@@ -227,6 +227,48 @@ defmodule Doctor.ModuleReportTest do
     assert module_report.module == "Doctor.ParentModule.Nested"
     assert module_report.doc_coverage == Decimal.new("100")
     assert module_report.spec_coverage == Decimal.new("100")
-    assert module_report.properties == [is_exception: false]
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: false]
+  end
+
+  test "build/1 should build the correct report for a protocol derivation" do
+    module_report =
+      Inspect.Doctor.DeriveProtocol
+      |> Code.fetch_docs()
+      |> ModuleInformation.build(Inspect.Doctor.DeriveProtocol)
+      |> ModuleInformation.load_file_ast()
+      |> ModuleInformation.load_user_defined_functions()
+      |> ModuleReport.build()
+
+    assert module_report.is_protocol_implementation == true
+    assert module_report.functions == 0
+    assert module_report.has_module_doc == false
+    assert module_report.has_struct_type_spec == :not_struct
+    assert module_report.missed_docs == 0
+    assert module_report.missed_specs == 0
+    assert module_report.module == "Inspect.Doctor.DeriveProtocol"
+    assert module_report.doc_coverage == nil
+    assert module_report.spec_coverage == nil
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: true]
+  end
+
+  test "build/1 should build the correct report for a protocol implementation" do
+    module_report =
+      Inspect.Doctor.ImplementProtocol
+      |> Code.fetch_docs()
+      |> ModuleInformation.build(Inspect.Doctor.ImplementProtocol)
+      |> ModuleInformation.load_file_ast()
+      |> ModuleInformation.load_user_defined_functions()
+      |> ModuleReport.build()
+
+    assert module_report.is_protocol_implementation == true
+    assert module_report.functions == 0
+    assert module_report.has_module_doc == false
+    assert module_report.has_struct_type_spec == :not_struct
+    assert module_report.missed_docs == 0
+    assert module_report.missed_specs == 0
+    assert module_report.module == "Inspect.Doctor.ImplementProtocol"
+    assert module_report.doc_coverage == nil
+    assert module_report.spec_coverage == nil
+    assert module_report.properties == [is_exception: false, is_protocol_implementation: true]
   end
 end

--- a/test/sample_files/derive_protocol.ex
+++ b/test/sample_files/derive_protocol.ex
@@ -1,0 +1,9 @@
+defmodule Doctor.DeriveProtocol do
+  @moduledoc """
+  An Example Derivation of a Protocol
+  """
+
+  @derive Inspect
+  defstruct [:foo, :bar]
+  @type t :: %__MODULE__{foo: String.t(), bar: non_neg_integer}
+end

--- a/test/sample_files/implement_protocol.ex
+++ b/test/sample_files/implement_protocol.ex
@@ -1,0 +1,18 @@
+defmodule Doctor.ImplementProtocol do
+  @moduledoc """
+  An Example Implementation of a Protocol
+  """
+
+  defstruct [:foo, :bar]
+  @type t :: %__MODULE__{foo: String.t(), bar: non_neg_integer}
+
+  defimpl Inspect do
+    import Inspect.Algebra
+
+    def inspect(struct, opts) do
+      doc = struct |> Map.from_struct() |> Map.to_list() |> to_doc(opts)
+
+      concat(["#ExampleDefImpl<", doc, ">"])
+    end
+  end
+end


### PR DESCRIPTION
In our code base we make use of a lot of protocols. Doctor raises errors on all protocol implementations (as described in #45). 

This PR fixes this issue by ignoring protocol implementations when evaluating documentation and spec coverage. 

Fixes #45 