### PR TITLE
Make Doctor installable as an escript executable

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,20 @@ def deps do
 end
 ```
 
+You can also install Doctor globally by executing the following
+from the command line:
+
+```bash
+$ mix escript.install hex doctor
+```
+
+To install from the master branch, rather than the latest release,
+the following command can be used:
+
+```bash
+$ mix escript.install github akoutmos/doctor
+```
+
 Documentation can be found at [https://hexdocs.pm/doctor](https://hexdocs.pm/doctor).
 
 ## Comparison with other tools

--- a/lib/mix/tasks/doctor.ex
+++ b/lib/mix/tasks/doctor.ex
@@ -44,6 +44,11 @@ defmodule Mix.Tasks.Doctor do
   @recursive true
   @umbrella_accumulator Doctor.Umbrella
 
+  # For escript entry
+  def main(args) do
+    run(args)
+  end
+
   @impl true
   def run(args) do
     cli_arg_opts = parse_cli_args(args)

--- a/mix.exs
+++ b/mix.exs
@@ -27,7 +27,8 @@ defmodule Doctor.MixProject do
         "coveralls.post": :test,
         "coveralls.html": :test,
         "coveralls.github": :test
-      ]
+      ],
+      escript: [main_module: Mix.Tasks.Doctor]
     ]
   end
 


### PR DESCRIPTION
I reproduced what is done in https://github.com/nccgroup/sobelow. This can be tested with `mix escript.install github dmarcoux/doctor branch escript`.