### PR TITLE
fix: ignore any non-Elixir modules.

### DIFF
--- a/lib/cli/cli.ex
+++ b/lib/cli/cli.ex
@@ -15,6 +15,7 @@ defmodule Doctor.CLI do
     Project.config()
     |> Keyword.get(:app)
     |> get_application_modules()
+    |> Enum.filter(fn module -> String.starts_with?(to_string(module), "Elixir.") end)
 
     # Fetch the module information from the list of application modules
     |> Enum.map(&generate_module_entry/1)


### PR DESCRIPTION
If a mix project contains any modules which are not generated by the Elixir compiler (eg `.erl` files in the `src/` directory), then it will not be prepended by `Elixir.`, so we can skip it.

Closes #43.