### PR TITLE
use Logger.warning

### DIFF
--- a/lib/config.ex
+++ b/lib/config.ex
@@ -110,7 +110,7 @@ defmodule Doctor.Config do
   end
 
   defp warn_deprecation(_bool, val) do
-    Logger.warn("""
+    Logger.warning("""
     :moduledoc_required in #{Config.config_file()} is a deprecated option. \
     Now running with the equivalent :min_overall_moduledoc_coverage #{val} \
     but you should replace the deprecated option with the new one to avoid \

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,7 @@ defmodule Doctor.MixProject do
     [
       app: :doctor,
       version: "0.21.0",
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       name: "Doctor",
       source_url: @source_url,
       homepage_url: "https://hex.pm/packages/doctor",


### PR DESCRIPTION
While use this in our Elixir 1.16 repository I noticed this deprecation warning. I am not sure whether it is ok to update the elixir version. If it is not I can change the code to use `System.version/0` to check whether to use `warn/1` or `warning/1` (introduced in Elixir 1.11).