### PR TITLE
Fix elixir warning and typo in stdout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Fix deprecated Elixir `Logger.warn()` to `Logger.warning()`.
+
 ## [0.21.0] - 2022-11-19
 
 ### Fixed

--- a/lib/config.ex
+++ b/lib/config.ex
@@ -110,7 +110,7 @@ defmodule Doctor.Config do
   end
 
   defp warn_deprecation(_bool, val) do
-    Logger.warn("""
+    Logger.warning("""
     :moduledoc_required in #{Config.config_file()} is a deprecated option. \
     Now running with the equivalent :min_overall_moduledoc_coverage #{val} \
     but you should replace the deprecated option with the new one to avoid \

--- a/lib/reporters/full.ex
+++ b/lib/reporters/full.ex
@@ -122,7 +122,7 @@ defmodule Doctor.Reporters.Full do
           """
           #{ANSI.red()}Doctor validation has failed because:
             * #{Enum.map_join(errs, ".\n  * ", &String.capitalize(&1))}.\
-          #{ANSI.reset()})")
+          #{ANSI.reset()}
           """
       end
 


### PR DESCRIPTION
1. fixes this typo
2. fixes elixir 1.15 Logger.warn deprecation warning
<img width="1218" alt="Screenshot 2024-04-03 at 13 13 41" src="https://github.com/akoutmos/doctor/assets/122370877/21e3f66f-5209-40da-82ce-d21795c9ec6b">
